### PR TITLE
Updated Message.php

### DIFF
--- a/src/Prowl/Message.php
+++ b/src/Prowl/Message.php
@@ -88,9 +88,15 @@ namespace Prowl {
 		 * @return void
 		 */
 		public function setUrl($sUrl) {
-			$sUrl = filter_var($sUrl, FILTER_VALIDATE_URL);
+			$bVarRes = boolval(filter_var($sUrl, FILTER_VALIDATE_URL));
 
-			if (!$sUrl) {
+			if (stripos($sUrl,'tel:') === 0 ) {
+				$bVarRes = true;
+			} else {
+				$bVarRes = false;
+			}
+
+			if (!$bVarRes) {
 				throw new \InvalidArgumentException("Given url [$sUrl] did not pass the validation.");
 			}
 


### PR DESCRIPTION
The built-in filter_var constant "FILTER_VALIDATE_URL" doesn't work with "tel:" URIs as described in RFC 3966. This commit lets you use tel:-uris as an valid url to send with prowl