### PR TITLE
Use (bool) for compatibility with PHP < 5.5 (#1)

### DIFF
--- a/src/Prowl/Message.php
+++ b/src/Prowl/Message.php
@@ -88,7 +88,7 @@ namespace Prowl {
 		 * @return void
 		 */
 		public function setUrl($sUrl) {
-			$bVarRes = boolval(filter_var($sUrl, FILTER_VALIDATE_URL));
+			$bVarRes = (bool)filter_var($sUrl, FILTER_VALIDATE_URL);
 
 			if (stripos($sUrl,'tel:') === 0 ) {
 				$bVarRes = true;


### PR DESCRIPTION
boolval() is available from PHP 5.5. As this package is compatible with PHP >= 5.3, use (bool)