### PR TITLE
Php72 fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.iml
 .idea/**
 build/
+vendor/
+composer.lock

--- a/src/Prowl/Connector.php
+++ b/src/Prowl/Connector.php
@@ -258,7 +258,7 @@ namespace Prowl {
 				$aParams['url'] = $oMessage->getUrl();
 			}
 
-			array_map(create_function('$sAryVal', 'return str_replace("\\n","\n", $sAryVal);'), $aParams);
+			array_map(function($sAryVal) { return str_replace("\\n","\n", $sAryVal); }, $aParams);
 
 			$sContextUrl = $this->sPushEndpoint;
 


### PR DESCRIPTION
`create_function` has been depreciated in php 7.2. Updated to use an anonymous function. 